### PR TITLE
Fix comment typo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -421,7 +421,7 @@ impl App {
             faint_bg_color: Color32::from_gray(242),
             extreme_bg_color: Color32::from_gray(255), // e.g. TextEdit background
             code_bg_color: Color32::from_gray(230),
-            warn_fg_color: Color32::from_rgb(255, 0, 0), // red also, beecause orange doesn't look great because of https://github.com/emilk/egui/issues/1455
+            warn_fg_color: Color32::from_rgb(255, 0, 0), // red also, because orange doesn't look great because of https://github.com/emilk/egui/issues/1455
             error_fg_color: Color32::from_rgb(255, 0, 0), // red
             window_shadow: Shadow::big_light(),
             popup_shadow: Shadow::small_light(),


### PR DESCRIPTION
## Summary
- correct a misspelling in the theme configuration comment

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f9fd75dd8832e9b0d3e40bdd4627d